### PR TITLE
Refactor data fetching to use Next.js API Routes instead of client-side fetch

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  // Validate input using Zod
+  const parse = loginSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.errors }, { status: 400 });
+  }
+  const { email, password } = parse.data;
+
+  // Check for user
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid email or password.' }, { status: 401 });
+  }
+
+  // Validate password
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) {
+    return NextResponse.json({ error: 'Invalid email or password.' }, { status: 401 });
+  }
+
+  // Issue JWT
+  const token = jwt.sign({ userId: user.id, email: user.email }, JWT_SECRET, { expiresIn: '7d' });
+
+  return NextResponse.json({ token });
+}

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import jwt from 'jsonwebtoken';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get('authorization');
+  if (!auth) return NextResponse.json({ error: 'No token' }, { status: 401 });
+
+  const token = auth.replace('Bearer ', '');
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as { userId: number };
+    const user = await prisma.user.findUnique({ where: { id: payload.userId } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    return NextResponse.json({ id: user.id, email: user.email });
+  } catch {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+  }
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import bcrypt from 'bcrypt';
+
+const prisma = new PrismaClient();
+
+const registerSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8, 'Password must be at least 8 characters long.'),
+});
+
+// Register a new user
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  // Validate input using Zod
+  const parse = registerSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.errors }, { status: 400 });
+  }
+  const { email, password } = parse.data;
+
+  // Check for duplicate email
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    return NextResponse.json({ error: 'Email already exists.' }, { status: 409 });
+  }
+
+  // Hash password
+  const passwordHash = await bcrypt.hash(password, 10);
+
+  // Create user
+  const user = await prisma.user.create({
+    data: { email, passwordHash },
+  });
+
+  return NextResponse.json({ id: user.id, email: user.email });
+}

--- a/app/api/coin/[coinId]/ohlc/route.ts
+++ b/app/api/coin/[coinId]/ohlc/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const cache: Record<string, { data: any; time: number }> = {};
+const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes (ms unit)
+
+export async function GET(req: NextRequest, { params }: { params: { coinId: string } }) {
+  const { coinId } = params;
+  const now = Date.now();
+
+  // If the cache is valid, return the cached data
+  if (cache[coinId] && now - cache[coinId].time < CACHE_DURATION) {
+    return NextResponse.json(cache[coinId].data);
+  }
+
+  // If the cache is not valid, fetch the data from the external API
+  console.log(`[API] Fetching OHLC data for coin: ${coinId} from Coingecko`);
+  const res = await fetch(`https://api.coingecko.com/api/v3/coins/${coinId}/ohlc?vs_currency=usd&days=14`);
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Failed to fetch coin history' }, { status: 500 });
+  }
+  const data = await res.json();
+
+  // Update the cache
+  cache[coinId] = { data, time: now };
+  return NextResponse.json(data);
+}

--- a/app/api/coin/[coinId]/route.ts
+++ b/app/api/coin/[coinId]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const cache: Record<string, { data: any; time: number }> = {};
+const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes (ms unit)
+
+export async function GET(req: NextRequest, { params }: { params: { coinId: string } }) {
+  const { coinId } = params;
+  const now = Date.now();
+
+  // If the cache is valid, return the cached data
+  if (cache[coinId] && now - cache[coinId].time < CACHE_DURATION) {
+    return NextResponse.json(cache[coinId].data);
+  }
+
+  // If the cache is not valid, fetch the data from the external API
+  console.log(`[API] Fetching coin info for coin: ${coinId} from Coingecko`);
+  const res = await fetch(`https://api.coingecko.com/api/v3/coins/${coinId}?localization=false`);
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Failed to fetch coin info' }, { status: 500 });
+  }
+  const data = await res.json();
+
+  // Update the cache
+  cache[coinId] = { data, time: now };
+  return NextResponse.json(data);
+}

--- a/app/api/coins/popular/route.ts
+++ b/app/api/coins/popular/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, NextRequest } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient({
+  log: [
+    { emit: 'event', level: 'query' },
+    { emit: 'event', level: 'info' },
+    { emit: 'event', level: 'warn' },
+    { emit: 'event', level: 'error' },
+  ],
+});
+
+prisma.$on('query', (e) => {
+  console.log(`[PRISMA QUERY] ${e.query} | params: ${e.params} | duration: ${e.duration}ms`);
+});
+
+// Get the top 5 most popular coins
+export async function GET() {
+  console.time('API /api/coins/popular');
+  const top = await prisma.coinViewCount.findMany({
+    orderBy: { count: 'desc' },
+    take: 5,
+    select: { coinId: true, count: true },
+  });
+  console.timeEnd('API /api/coins/popular');
+  return NextResponse.json(top);
+}
+
+// Increment the view count for a coin
+export async function POST(req: NextRequest) {
+  const { coinId } = await req.json();
+  if (!coinId) return NextResponse.json({ error: 'coinId required' }, { status: 400 });
+  // Upsert: increment if exists, else create
+  const updated = await prisma.coinViewCount.upsert({
+    where: { coinId },
+    update: { count: { increment: 1 } },
+    create: { coinId, count: 1 },
+  });
+  return NextResponse.json(updated);
+}

--- a/app/api/coins/route.ts
+++ b/app/api/coins/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+let cachedData: any = null;
+let lastFetchTime = 0;
+const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes (ms unit)
+
+export async function GET() {
+  const now = Date.now();
+
+  // If the cache is valid, return the cached data
+  if (cachedData && now - lastFetchTime < CACHE_DURATION) {
+    return NextResponse.json(cachedData);
+  }
+
+  // If the cache is not valid, fetch the data from the external API
+  console.log('[API] Fetching coins list from Coingecko');
+  const res = await fetch('https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=50&page=1');
+  const data = await res.json();
+
+  // Update the cache
+  cachedData = data;
+  lastFetchTime = now;
+
+  return NextResponse.json(data);
+}

--- a/app/api/favorites/[coinId]/route.ts
+++ b/app/api/favorites/[coinId]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+// Get user ID from request
+function getUserIdFromRequest(req: NextRequest): number | null {
+  const auth = req.headers.get('authorization');
+  if (!auth) return null;
+  // Remove Bearer prefix from token
+  try {
+    const token = auth.replace('Bearer ', '');
+    const payload = jwt.verify(token, JWT_SECRET) as { userId: number };
+    return payload.userId;
+  } catch {
+    return null;
+  }
+}
+
+// Delete a coin from user's favorites
+export async function DELETE(req: NextRequest, { params }: { params: { coinId: string } }) {
+  const userId = getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { coinId } = params;
+  await prisma.favoriteCoin.deleteMany({ where: { userId, coinId } });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/favorites/route.ts
+++ b/app/api/favorites/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+// Get user ID from request
+function getUserIdFromRequest(req: NextRequest): number | null {
+  const auth = req.headers.get('authorization');
+  if (!auth) return null;
+  try {
+    const token = auth.replace('Bearer ', '');
+    const payload = jwt.verify(token, JWT_SECRET) as { userId: number };
+    return payload.userId;
+  } catch {
+    return null;
+  }
+}
+
+// Get user's favorite coins
+export async function GET(req: NextRequest) {
+  const userId = getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const favorites = await prisma.favoriteCoin.findMany({ where: { userId } });
+  return NextResponse.json(favorites);
+}
+
+// Add a coin to user's favorites
+export async function POST(req: NextRequest) {
+  const userId = getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { coinId } = await req.json();
+  const favorite = await prisma.favoriteCoin.create({ data: { userId, coinId } });
+  return NextResponse.json(favorite);
+}

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient({
+  log: [
+    { emit: 'event', level: 'query' },
+    { emit: 'event', level: 'info' },
+    { emit: 'event', level: 'warn' },
+    { emit: 'event', level: 'error' },
+  ],
+});
+
+prisma.$on('query', (e) => {
+  console.log(`[PRISMA QUERY] ${e.query} | params: ${e.params} | duration: ${e.duration}ms`);
+});
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+// Get user ID from request
+function getUserIdFromRequest(req: NextRequest): number | null {
+  const auth = req.headers.get('authorization');
+  // Remove Bearer prefix from token
+  if (!auth) return null;
+  try {
+    const token = auth.replace('Bearer ', '');
+    const payload = jwt.verify(token, JWT_SECRET) as { userId: number };
+    return payload.userId;
+  } catch {
+    return null;
+  }
+}
+
+// Get user's view history
+export async function GET(req: NextRequest) {
+  console.time('API /api/history');
+  const userId = getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const history = await prisma.viewHistory.findMany({
+    where: { userId },
+    orderBy: { viewedAt: 'desc' },
+    take: 10,
+    select: { coinId: true, viewedAt: true },
+  });
+  console.timeEnd('API /api/history');
+  return NextResponse.json(history);
+}
+
+// Add a coin to user's view history
+export async function POST(req: NextRequest) {
+  const userId = getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { coinId } = await req.json();
+  const record = await prisma.viewHistory.create({ data: { userId, coinId } });
+  return NextResponse.json(record);
+}


### PR DESCRIPTION
What was changed
- Created new API handlers under `app/api/coins`, `app/api/popular`, etc.
- Removed direct `fetch()` calls from client components
- Updated data access to use internal API endpoints (`/api/coins`, etc.)
- Ensured compatibility with SSR and client-side caching (React Query)

Why this change
- Prevents exposing external API calls on the client
- Enables server-side rendering for improved initial load performance
- Centralizes API logic for better control and future caching
- Lays foundation for backend-side error handling and throttling